### PR TITLE
docs: refresh repository readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,81 @@
-# BrainDrive-Docs
-Up to date, easy to follow developer documentation.
+# BrainDrive Documentation Hub
 
-## Documentation Workflow Checklist
-1. Open the workspace file at `BrainDrive-Core/.vscode/brain-drive.code-workspace` in VS Code so `BrainDrive-Core` and `BrainDrive-Docs` show up together in the Explorer.
-2. In Explorer (`Ctrl+Shift+E`), expand `BrainDrive-Docs` and edit the Markdown file you need; peek at `BrainDrive-Core` whenever you need context or assets.
-3. Preview your edits with `Ctrl+Shift+V` to confirm headings, links, and tables render as expected.
-4. Run `Ctrl+Shift+F` with `BrainDrive-Docs/**` in “files to include” to update related references across the docs set.
-5. Open the Source Control view, review the diff, then stage and commit the updated files with a clear message.
-6. (Optional) For a browser preview, run `npm install` once and then `npm run start` inside `BrainDrive-Docs`; stop the local server with `Ctrl+C` when finished.
+BrainDrive-Docs is the home for BrainDrive's public developer documentation. The site is powered by [Docusaurus 3](https://docusaurus.io/) and aggregates content from the main BrainDrive codebase, plugin templates, and dedicated documentation written in this repository.
+
+## Quick start
+
+1. **Install prerequisites**
+   - Node.js ≥ 18
+   - npm (bundled with Node.js)
+2. **Install dependencies**
+   ```bash
+   npm install
+   ```
+3. **Start the local site**
+   ```bash
+   npm run start
+   ```
+   The site opens at <http://localhost:3000>. Saved changes to Markdown/MDX or React components trigger hot reloads.
+
+### Other useful scripts
+
+| Command | Description |
+| ------- | ----------- |
+| `npm run build` | Produces a production build in `build/`. |
+| `npm run serve` | Serves the build output locally for verification. |
+| `npm run typecheck` | Runs the TypeScript compiler against the custom theme/components. |
+| `npm run clear` | Clears cached Docusaurus metadata—helpful when sidebar or plugin changes are not picked up. |
+| `npm run sync` | Re-syncs documentation from external BrainDrive repositories (see below). |
+
+## Repository layout
+
+```
+BrainDrive-Docs/
+├── docs/              # Hand-written docs that live only in this repo (tutorials, intro, etc.)
+├── docs-core/         # Synced docs from BrainDrive-Core (see `npm run sync`).
+├── docs-services/     # Service-specific docs (hand-written).
+├── docs-plugins/      # Plugin docs; includes synced sections such as ai-chat.
+├── docs-template/     # Synced docs from the BrainDrive Plugin Template repo.
+├── blog/              # Blog posts (MDX) displayed in the Docs site blog.
+├── site/              # Additional MDX/Markdown content used for the marketing landing pages.
+├── src/               # Custom React theme/components and client-side behavior.
+├── static/            # Static assets copied verbatim into the build output.
+├── sidebars*.ts       # Sidebar definitions grouping documents by product area.
+├── docusaurus.config.ts  # Docusaurus site configuration.
+└── scripts/sync.mjs   # Sync utility for importing docs from other repos.
+```
+
+## Writing and organizing content
+
+- **File format**: Use Markdown (`.md`) or MDX (`.mdx`). Docusaurus front matter (YAML fenced by `---`) sets titles, descriptions, and tags.
+- **Placement**: Choose the folder that matches the topic (core, services, plugins, templates). If a new top-level area is required, add the folder under the project root and register it in the appropriate `sidebars.*.ts` file.
+- **Sidebars & navigation**: Update the relevant `sidebars.<area>.ts` file to expose new docs in the left-hand navigation. For shared/global docs, use `sidebars.ts`.
+- **Assets**: Place images or downloadable assets in the same folder as the referencing doc or under `static/`. Use relative paths when possible (e.g., `![Alt](./img/diagram.png)`).
+- **MDX components**: Import reusable components from `src/components`. Avoid heavy logic in MDX; prefer extracting it into a React component.
+
+## Syncing external documentation
+
+Running `npm run sync` clones remote repositories into a temporary cache and copies curated documentation into this project:
+
+- `BrainDriveAI/BrainDrive-Core` → `docs-core/`
+- `BrainDriveAI/PluginTemplate` → `docs-template/`
+- `DJJones66/BrainDriveChat` → `docs-plugins/ai-chat/` (optional; skips if cloning fails)
+
+The script sanitizes Markdown for compatibility, removes unsupported Kramdown attributes, and ensures each synced section has an `intro.md`. Use a `GH_TOKEN` environment variable with appropriate GitHub access to avoid rate limits for private repositories.
+
+> ⚠️ The sync script replaces the entire target directories. Commit any local edits before running it or they may be lost.
+
+## Contribution workflow
+
+1. Use the combined BrainDrive workspace at `BrainDrive-Core/.vscode/brain-drive.code-workspace` if you need to reference product code while editing docs.
+2. Make changes in the relevant Markdown/MDX files and preview with VS Code (`Ctrl+Shift+V`) or the local dev server.
+3. Update sidebars and navigation links as needed, then run `npm run typecheck` (and optionally `npm run build`) before committing.
+4. Stage and commit with a descriptive message. Each PR should include a quick summary of the affected doc areas.
+
+## Deployment
+
+Production builds are created via `npm run build` and deployed from the generated `build/` directory. The deploy process depends on your hosting setup (e.g., GitHub Pages, Vercel). Ensure CI runs the build and TypeScript checks to catch broken links or MDX issues before publishing.
+
+## Support
+
+If you spot issues or need access to the synced repositories, reach out in the BrainDrive engineering Slack or open an issue in this repository.


### PR DESCRIPTION
## Summary
- replace the minimal README with a detailed overview of the docs site
- document local development commands, repository layout, and sync workflow
- outline contribution guidance and deployment expectations

## Testing
- npm run typecheck *(fails: missing @theme/Heading type definitions in existing source files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ac47ebcc8320bc08d13a0e0716cc