### PR TITLE
Add shared screenshots directory

### DIFF
--- a/static/img/screenshots/README.md
+++ b/static/img/screenshots/README.md
@@ -1,0 +1,5 @@
+# Screenshots
+
+Store shared documentation screenshots in this directory so they can be referenced from multiple locations without duplicating assets.
+
+Use paths like `/img/screenshots/<file-name>` in Docusaurus markdown.


### PR DESCRIPTION
## Summary
- add a `static/img/screenshots` directory for shared docs assets
- document how to reference the screenshots from Markdown

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d5abdb6de08320ba797065de460402