### PR TITLE
Update homepage get started heading

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -47,7 +47,7 @@ function GetStarted(): ReactNode {
     <section className={styles.getStartedSection}>
       <div className="container">
         <Heading as="h2" className={styles.getStartedTitle}>
-          Get Started in 3 Steps
+          Get Started
         </Heading>
         <div className="row">
           {steps.map((s, i) => (


### PR DESCRIPTION
## Summary
- update the homepage "Get Started" section heading to drop the "in 3 Steps" wording

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5bf95eac88320ae0a8cc259e1e6c2