### PR TITLE
Increase homepage hero spacing

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -4,7 +4,7 @@
  */
 
 .heroBanner {
-  padding: 3rem 0;
+  padding: 3.6rem 0;
   text-align: center;
   position: relative;
   overflow: hidden;
@@ -12,7 +12,7 @@
 
 @media screen and (max-width: 996px) {
   .heroBanner {
-    padding: 2rem;
+    padding: 2.4rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- increase the homepage hero section padding by 20% to make the blue banner taller on all breakpoints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5bff2af908320be9f906cbe310195