### PR TITLE
Update plugins CTA label on homepage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,7 +34,7 @@ function GetStarted(): ReactNode {
       title: 'Use Existing Plugins',
       desc: 'Explore and enable plugins from the ecosystem.',
       to: '/plugins/intro',
-      cta: 'Browse Plugins',
+      cta: 'Plugins Overview',
     },
     {
       title: 'Build Your Own Plugins',


### PR DESCRIPTION
## Summary
- rename the homepage plugin CTA button from "Browse Plugins" to "Plugins Overview" to match the new wording

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5e4d0afe08320bd09322cf99de5c2