### PR TITLE
Fix owner guide images on GitHub

### DIFF
--- a/docs-core/OWNER_USER_GUIDE.md
+++ b/docs-core/OWNER_USER_GUIDE.md
@@ -19,15 +19,15 @@ Think **WordPress but for AI**: Install BrainDrive-Core, then add or develop plu
 
 1. A web‑based Chat interface for interacting with AI models
 
-![BrainDrive chat interface with plugin manager and page builder panes](/static/img/screenshots/AI-Chat-Interface.png)
+![BrainDrive chat interface with plugin manager and page builder panes](https://raw.githubusercontent.com/BrainDriveAI/BrainDrive-Docs/main/static/img/screenshots/AI-Chat-Interface.png)
 
 2. A built‑in Plugin Manager to install/manage extensions
 
- ![BrainDrive Plugin Manager Screenshot](/static/img/screenshots/plugin-manager.png)
+ ![BrainDrive Plugin Manager Screenshot](https://raw.githubusercontent.com/BrainDriveAI/BrainDrive-Docs/main/static/img/screenshots/plugin-manager.png)
 
 3. A Page Builder for creating custom UIs without code
 
-  ![BrainDrive Page Builder Screenshot](/static/img/screenshots/Page-Builder.png)
+  ![BrainDrive Page Builder Screenshot](https://raw.githubusercontent.com/BrainDriveAI/BrainDrive-Docs/main/static/img/screenshots/Page-Builder.png)
   
  4. Example plugins, tutorials, and developer resources
 
@@ -67,11 +67,11 @@ To use the Ollama Plugin to run local AI models:
 1. Install Ollama from Ollama.com
 3. Go to BrainDrive Settings & Install Your Preferred Model(s):
 
-![BrainDrive Ollama Settings Page](/static/img/screenshots/ollama-settings-screebshot.png)
+![BrainDrive Ollama Settings Page](https://raw.githubusercontent.com/BrainDriveAI/BrainDrive-Docs/main/static/img/screenshots/ollama-settings-screebshot.png)
 
 4. Chat Locally — All conversations stay on your machine:
 
-![chatting with an Ollama model in BrainDrive](/static/img/screenshots/choosing-a-model.png)
+![chatting with an Ollama model in BrainDrive](https://raw.githubusercontent.com/BrainDriveAI/BrainDrive-Docs/main/static/img/screenshots/choosing-a-model.png)
 
 ### Option B: API-Based Models via BrainDrive's OpenRouter Plugin:
 
@@ -81,10 +81,10 @@ To use OpenRouter models in your BrainDrive:
 
 1. Signup at OpenRouter.com
 2. Generate an OpenRouter API Key
-![OpenRouter API key generation](/static/img/screenshots/openrouter-api-keys-page.png)
+![OpenRouter API key generation](https://raw.githubusercontent.com/BrainDriveAI/BrainDrive-Docs/main/static/img/screenshots/openrouter-api-keys-page.png)
 3. Add in Settings → AI Providers 
    * Enter your API key  
- ![Enter your API key](/static/img/screenshots/adding-openrouter-api-key-to-braindrive.png)
+ ![Enter your API key](https://raw.githubusercontent.com/BrainDriveAI/BrainDrive-Docs/main/static/img/screenshots/adding-openrouter-api-key-to-braindrive.png)
 4. Now your models will show in the model dropdown on your AI Chat Page
 
 ### Option C: Build Your Own Model Serving Plugin for the provider of your choice. 
@@ -110,7 +110,7 @@ The **Page Builder** is where BrainDrive's modularity shines. Create task-specif
 5. **Arrange** and Resize** components to fit your workflow  
 6. **Publish** your layout
 
-![Building a page in BrainDrive](/static/img/screenshots/building-a-page.png)
+![Building a page in BrainDrive](https://raw.githubusercontent.com/BrainDriveAI/BrainDrive-Docs/main/static/img/screenshots/building-a-page.png)
 
 ### Future Page Ideas for Different Workflows
 
@@ -132,7 +132,7 @@ BrainDrive's plugin system is designed for safety and simplicity. All plugins ar
 3. **Install**: Plugin Manager → Install Plugin → Paste URL → Confirm  
 4. **Use Components**: New components appear immediately in the Page Builder
 
-![installing a plugin in BrainDrive](/static/img/screenshots/installing-plugin.png)
+![installing a plugin in BrainDrive](https://raw.githubusercontent.com/BrainDriveAI/BrainDrive-Docs/main/static/img/screenshots/installing-plugin.png)
 
 ### Plugin Management
 
@@ -150,7 +150,7 @@ Personas allow you to easily customize the behavior of the AI models you use in 
 
 Personas can be easily used across any AI chat, and allow you to control the system prompt, temperature, top P, and more. 
 
-![BrainDrive Personas](/static/img/screenshots/personas.png)
+![BrainDrive Personas](https://raw.githubusercontent.com/BrainDriveAI/BrainDrive-Docs/main/static/img/screenshots/personas.png)
 
 ## Building on BrainDrive
 
@@ -179,7 +179,7 @@ Ready to get started building? Be up and running in minutes with BrainDrive's [P
 **Primary Resources**:
 
 * **Community Forum**: [community.braindrive.ai](https://community.braindrive.ai/) — Questions, help, ideas, weekly updates  
-* **Guides**: [Github.come/BrainDriveAI](Github.come/BrainDriveAI) for full documentation and tutorials
+* **Guides**: [github.com/BrainDriveAI](https://github.com/BrainDriveAI) for full documentation and tutorials
 * **Documentation** Each repo has full technical references in the root directory.
 * **GitHub Issues**: Report bugs and request features  
 * **Plugin Marketplace**: Share and discover new plugins


### PR DESCRIPTION
## Summary
- update Owner User Guide image references to use raw GitHub URLs so they render inline on GitHub while still working in Docusaurus

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d99e3980708320b89e47e15e28b38a